### PR TITLE
`date_utils` legacy import

### DIFF
--- a/.github/workflows/bump_version_number.yml
+++ b/.github/workflows/bump_version_number.yml
@@ -11,14 +11,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        # with: 
-          # token: ${{ secrets.BERMUDA_CI }}
+        with: 
+          token: ${{ secrets.BERMUDA_CI }}
 
       - name: Apply Version Release Rules
         id: get_tag_version
         uses: mathieudutour/github-tag-action@v6.0
         with:
-          # github_token: ${{ secrets.BERMUDA_CI }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           dry_run: true
           tag_prefix: ""
           custom_release_rules: MAJOR:major,MINOR:minor,PATCH:patch,FIX:patch,BUG:patch,FEATURE:minor
@@ -28,5 +28,5 @@ jobs:
 
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          # github_token: ${{ secrets.BERMUDA_CI }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           commit_message: Automated version bump to ${{ steps.get_tag_version.outputs.new_tag }}

--- a/.github/workflows/bump_version_number.yml
+++ b/.github/workflows/bump_version_number.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
     steps:
       - uses: actions/checkout@v4
         with: 

--- a/.github/workflows/bump_version_number.yml
+++ b/.github/workflows/bump_version_number.yml
@@ -28,5 +28,5 @@ jobs:
 
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          github_token: ${{ secrets.BERMUDA_CI }}
+          # github_token: ${{ secrets.BERMUDA_CI }}
           commit_message: Automated version bump to ${{ steps.get_tag_version.outputs.new_tag }}

--- a/.github/workflows/bump_version_number.yml
+++ b/.github/workflows/bump_version_number.yml
@@ -11,14 +11,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with: 
-          token: ${{ secrets.BERMUDA_CI }}
+        # with: 
+          # token: ${{ secrets.BERMUDA_CI }}
 
       - name: Apply Version Release Rules
         id: get_tag_version
         uses: mathieudutour/github-tag-action@v6.0
         with:
-          github_token: ${{ secrets.BERMUDA_CI }}
+          # github_token: ${{ secrets.BERMUDA_CI }}
           dry_run: true
           tag_prefix: ""
           custom_release_rules: MAJOR:major,MINOR:minor,PATCH:patch,FIX:patch,BUG:patch,FEATURE:minor

--- a/bermuda/__init__.py
+++ b/bermuda/__init__.py
@@ -17,7 +17,7 @@ from .matrix import (
 from .utils import *
 from .factory import Triangle
 from .triangle import TriangleSlice
-import .date_utils as date_utils
+import bermuda.date_utils as date_utils
 from .date_utils import *
 
 local_dir = os.path.dirname(os.path.abspath(__file__))

--- a/bermuda/__init__.py
+++ b/bermuda/__init__.py
@@ -17,6 +17,7 @@ from .matrix import (
 from .utils import *
 from .factory import Triangle
 from .triangle import TriangleSlice
+import .date_utils as date_utils
 from .date_utils import *
 
 local_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
This keeps bermuda backwards-compatibile with carnac code