### PR TITLE
fix: quantitative x-axis for dev lags in `plot_atas`

### DIFF
--- a/bermuda/plot.py
+++ b/bermuda/plot.py
@@ -517,12 +517,12 @@ def _plot_atas(
         alt.Tooltip("period_start:T", title="Period Start"),
         alt.Tooltip("period_end:T", title="Period End"),
         alt.Tooltip("evaluation_date:T", title="Evaluation Date"),
-        alt.Tooltip("dev_lag:O", title="Dev Lag (months)"),
+        alt.Tooltip("dev_lag:Q", title="Dev Lag (months)"),
         alt.Tooltip("metric:Q", title=name, format=".2f"),
     ]
 
     base = alt.Chart(metric_data, title=title).encode(
-        x=alt.X("dev_lag:N", axis=alt.Axis(labelAngle=0))
+        x=alt.X("dev_lag:Q")
         .title("Dev Lag (months)")
         .scale(padding=10),
         y=alt.X("metric:Q").title(name).scale(zero=False, padding=10),
@@ -1027,7 +1027,7 @@ def _plot_ballistic(
             alt.Tooltip("period_start:T", title="Period Start"),
             alt.Tooltip("period_end:T", title="Period End"),
             alt.Tooltip("evaluation_date:T", title="Evaluation Date"),
-            alt.Tooltip("dev_lag:O", title="Dev Lag (months)"),
+            alt.Tooltip("dev_lag:Q", title="Dev Lag (months)"),
             alt.Tooltip(f"{name_x}:Q", format=".1f"),
             alt.Tooltip(f"{name_y}:Q", format=".1f"),
         ],

--- a/test/plot_test.py
+++ b/test/plot_test.py
@@ -13,7 +13,7 @@ def test_plot_data_completeness():
         metadata=Metadata(details={"id": 1})
     )
     test2 = test.derive_metadata(id=2)
-    test2.plot_data_completeness()
+    test2.plot_data_completeness().show()
     (test + test2).plot_data_completeness()
 
 def test_plot_data_completeness_with_predictions():
@@ -92,7 +92,6 @@ def test_plot_atas():
             "Paid": lambda cell, prev_cell: cell["paid_loss"] / prev_cell["paid_loss"], 
             "Reported": lambda cell, prev_cell: cell["reported_loss"] / prev_cell["reported_loss"]
         }, 
-        width=500, height=200,
     )
 
 


### PR DESCRIPTION
The x-axis for dev lags in `plot_atas` was declared as categorical, but quantitative allows for auto-scaling of the axis labels. In some plots, dev lags are categorical to help with spacing of markers (e.g. in `plot_data_completeness`) but it's not essential here.