### PR TITLE
fix: nicer format for large values in heatmap legend

### DIFF
--- a/bermuda/plot.py
+++ b/bermuda/plot.py
@@ -443,7 +443,7 @@ def _plot_heatmap(
         .encode(
             color=alt.when(selection)
             .then(
-                alt.Color("metric:Q", scale=alt.Scale(scheme="blueorange")).title(name)
+                alt.Color("metric:Q", scale=alt.Scale(scheme="blueorange"), legend=alt.Legend(title=name, format=".1s")).title(name)
             )
             .otherwise(
                 alt.value("gray"),
@@ -642,7 +642,7 @@ def _plot_growth_curve(
 
     color = (
         alt.Color("yearmonth(period_start):Q")
-        .scale(scheme="blueorange")
+        .scale(scheme="blueorange", reverse=True)
         .legend(title="Period Start")
     )
     color_none = color.legend(None)

--- a/test/plot_test.py
+++ b/test/plot_test.py
@@ -94,7 +94,7 @@ def test_plot_heatmap():
         },
         ncols=3,
     )
-    (test + test2).plot_heatmap()
+    (test + test2).plot_heatmap("Paid Loss", show_values=False)
     (test + test2 + test3 + test4 + test5).plot_heatmap()
     (test + test2 + test3 + test4 + test5).plot_heatmap(
         {"Earned Premium": lambda cell: cell["earned_premium"] / 1e6}


### PR DESCRIPTION
Formats large values in the heatmap legend in millions, not dollars.